### PR TITLE
feat: Update homepage carousel and restore franchisee video banner

### DIFF
--- a/home/ubuntu/franqueado.html
+++ b/home/ubuntu/franqueado.html
@@ -56,6 +56,24 @@
     </header>
 
     <main>
+      <section id="inicio" class="hero">
+    <video autoplay loop muted playsinline poster="assets/hero-video-poster.jpg" class="hero-background-video">
+    <source src="assets/videos/video_hero.mp4" type="video/mp4">
+    Seu navegador não suporta o elemento de vídeo.
+</video>
+
+    <div class="container">
+        <div class="hero-content fade-in-up">
+            <h1>SEJA UM FRANQUEADO</h1>
+            <p class="subtitle">Raza Óticas - A Ótica do Futuro</p>
+            <p style="font-size: 1.1rem; margin-bottom: 2rem; opacity: 0.9;">
+                Modelo de Negócio testado e comprovado!
+            </p>
+            <a href="#contato" class="cta-button">Receber Apresentação</a>
+            <a href="#contato" class="cta-button">Se Torne um Franqueado</a>
+        </div>
+    </div>
+</section>
         <section id="investimento" class="section investimento">
             <div class="container">
                 <h2 class="section-title">Oportunidade de Investimento</h2>

--- a/home/ubuntu/index.html
+++ b/home/ubuntu/index.html
@@ -76,7 +76,7 @@
         }
         .dots-container {
             text-align: center;
-            padding: 20px;
+            padding: 10px;
             background: #f1f1f1;
         }
         .dot {
@@ -124,13 +124,22 @@
       <section id="inicio" class="hero">
         <div class="carousel-container">
             <div class="carousel-slide fade">
-                <a href="#"><img src="modelos_carrossel/67-scaled-qvn77fehx2o82vjaaw4k6pvyxqdfsg369t4l5it08g.jpg" alt="Banner 1"></a>
+                <a href="#"><img src="assets/hero-background.jpg" alt="Banner 1"></a>
             </div>
             <div class="carousel-slide fade">
-                <a href="#"><img src="modelos_carrossel/68-scaled-qvn789hbzrteeeblf94meiapy296mrel1y04idkepc.jpg" alt="Banner 2"></a>
+                <a href="#"><img src="assets/promo1-hora.jpg" alt="Banner 2"></a>
             </div>
             <div class="carousel-slide fade">
-                <a href="#"><img src="modelos_carrossel/71-scaled-qvn7apu5u76cpqr93bbjww01sa5oqb5cq3brmdxegg.jpg" alt="Banner 3"></a>
+                <a href="#"><img src="assets/promo70-hero-poster.jpg" alt="Banner 3"></a>
+            </div>
+            <div class="carousel-slide fade">
+                <a href="#"><img src="assets/promo-antirreflexo-banner.jpg" alt="Banner 4"></a>
+            </div>
+            <div class="carousel-slide fade">
+                <a href="#"><img src="assets/promo-armacoes49-banner.jpg" alt="Banner 5"></a>
+            </div>
+            <div class="carousel-slide fade">
+                <a href="#"><img src="assets/promo-oculos-antigo.jpg" alt="Banner 6"></a>
             </div>
             <a class="prev" onclick="plusSlides(-1)">&#10094;</a>
             <a class="next" onclick="plusSlides(1)">&#10095;</a>
@@ -139,6 +148,9 @@
             <span class="dot" onclick="currentSlide(1)"></span>
             <span class="dot" onclick="currentSlide(2)"></span>
             <span class="dot" onclick="currentSlide(3)"></span>
+            <span class="dot" onclick="currentSlide(4)"></span>
+            <span class="dot" onclick="currentSlide(5)"></span>
+            <span class="dot" onclick="currentSlide(6)"></span>
         </div>
       </section>
 
@@ -198,7 +210,7 @@
             </div>
         </section>
 
-        <section id="seja-franqueado" class="section contato">
+        <section id="seja-franqueado" class="section contato" style="padding: 2rem 0;">
             <div class="container">
                 <a href="franqueado.html">
                     <img src="assets/seja-franqueado.png" alt="Arte da campanha Seja um Franqueado Raza Óticas" style="display: block; margin-left: auto; margin-right: auto; max-width: 80%; height: auto;">


### PR DESCRIPTION
- Updates the main page carousel with new banner images provided by the user.
- Restores the original video hero banner to the `franqueado.html` page.
- Reduces the size of the "Seja um Franqueado" section on the main page for better layout.
- All changes have been visually verified using Playwright.