### PR TITLE
feat: Make homepage carousel banners clickable

### DIFF
--- a/home/ubuntu/index.html
+++ b/home/ubuntu/index.html
@@ -123,22 +123,22 @@
       <section id="inicio" class="hero hero-home">
         <div class="carousel-container">
             <div class="carousel-slide fade">
-                <a href="#"><img src="assets/hero-background.jpg" alt="Banner 1"></a>
+                <a href="https://of.razaoticas.com/promo-2por299.html" target="_blank"><img src="assets/hero-background.jpg" alt="Banner 1"></a>
             </div>
             <div class="carousel-slide fade">
-                <a href="#"><img src="assets/promo1-hora.jpg" alt="Banner 2"></a>
+                <a href="https://of.razaoticas.com/promo-1hora" target="_blank"><img src="assets/promo1-hora.jpg" alt="Banner 2"></a>
             </div>
             <div class="carousel-slide fade">
-                <a href="#"><img src="assets/promo70-hero-poster.jpg" alt="Banner 3"></a>
+                <a href="https://of.razaoticas.com/promo70" target="_blank"><img src="assets/promo70-hero-poster.jpg" alt="Banner 3"></a>
             </div>
             <div class="carousel-slide fade">
-                <a href="#"><img src="assets/promo-antirreflexo-banner.jpg" alt="Banner 4"></a>
+                <a href="https://of.razaoticas.com/promo-antirreflexo.html" target="_blank"><img src="assets/promo-antirreflexo-banner.jpg" alt="Banner 4"></a>
             </div>
             <div class="carousel-slide fade">
-                <a href="#"><img src="assets/promo-armacoes49-banner.jpg" alt="Banner 5"></a>
+                <a href="https://of.razaoticas.com/promo-armacoes49.html" target="_blank"><img src="assets/promo-armacoes49-banner.jpg" alt="Banner 5"></a>
             </div>
             <div class="carousel-slide fade">
-                <a href="#"><img src="assets/promo-oculos-antigo.jpg" alt="Banner 6"></a>
+                <a href="https://of.razaoticas.com/promo-oculos-antigo.html" target="_blank"><img src="assets/promo-oculos-antigo.jpg" alt="Banner 6"></a>
             </div>
             <a class="prev">&#10094;</a>
             <a class="next">&#10095;</a>


### PR DESCRIPTION
This change adds the promotional links to the carousel banners on the homepage, as requested by the user. Each banner now links to its corresponding promotion page.

It also includes the investigation into the missing login page, which was found to be unrecoverable on a static site.