### PR TITLE
Corrects the 'Seja um Franqueado' link on all unit pages.

### DIFF
--- a/unidades/belo-horizonte/index.html
+++ b/unidades/belo-horizonte/index.html
@@ -86,7 +86,7 @@
                         <li><a href="#promocoes">Promoções</a></li>
 
                         <li><a href="#galeria-unidade">Galeria</a></li>
-                        <li><a href="../../index.html#contato">Seja Franqueado</a></li>
+                        <li><a href="../../franqueado.html">Seja Franqueado</a></li>
                         <li><a href="#contato-unidade">Contato</a></li>
                     </ul>
                 </nav>

--- a/unidades/cabo-frio/index.html
+++ b/unidades/cabo-frio/index.html
@@ -60,7 +60,7 @@
                         <li><a href="#servicos">Serviços</a></li>
                         <li><a href="#promocoes">Promoções</a></li>
                         <li><a href="#galeria-unidade">Galeria</a></li>
-                        <li><a href="../../index.html#contato">Seja Franqueado</a></li>
+                        <li><a href="../../franqueado.html">Seja Franqueado</a></li>
                         <li><a href="#contato-unidade">Contato</a></li>
                     </ul>
                 </nav>

--- a/unidades/campos-dos-goytacazes/index.html
+++ b/unidades/campos-dos-goytacazes/index.html
@@ -80,7 +80,7 @@
                         <li><a href="#promocoes">Promoções</a></li>
 
                         <li><a href="#galeria-unidade">Galeria</a></li>
-                        <li><a href="../../index.html#contato">Seja Franqueado</a></li>
+                        <li><a href="../../franqueado.html">Seja Franqueado</a></li>
                         <li><a href="#contato-unidade">Contato</a></li>
                     </ul>
                 </nav>

--- a/unidades/cariacica/index.html
+++ b/unidades/cariacica/index.html
@@ -79,7 +79,7 @@
                          <li><a href="#servicos">Serviços</a></li>
                          <li><a href="#promocoes">Promoções</a></li>
                          <li><a href="#galeria-unidade">Galeria</a></li>
-                         <li><a href="../../index.html#contato">Seja Franqueado</a></li>
+                         <li><a href="../../franqueado.html">Seja Franqueado</a></li>
                          <li><a href="#contato-unidade">Contato</a></li>
                     </ul>
                 </nav>

--- a/unidades/juiz-de-fora/index.html
+++ b/unidades/juiz-de-fora/index.html
@@ -69,7 +69,7 @@
                         <li><a href="#servicos">Serviços</a></li>
                         <li><a href="#promocoes">Promoções</a></li>
                         <li><a href="#galeria-unidade">Galeria</a></li>
-                        <li><a href="../../index.html#contato">Seja Franqueado</a></li>
+                        <li><a href="../../franqueado.html">Seja Franqueado</a></li>
                         <li><a href="#contato-unidade">Contato</a></li>
                     </ul>
                 </nav>

--- a/unidades/laranjeiras/index.html
+++ b/unidades/laranjeiras/index.html
@@ -69,7 +69,7 @@
                         <li><a href="#servicos">Serviços</a></li>
                         <li><a href="#promocoes">Promoções</a></li>
                         <li><a href="#galeria-unidade">Galeria</a></li>
-                        <li><a href="../../index.html#contato">Seja Franqueado</a></li>
+                        <li><a href="../../franqueado.html">Seja Franqueado</a></li>
                         <li><a href="#contato-unidade">Contato</a></li>
                     </ul>
                 </nav>

--- a/unidades/macae/index.html
+++ b/unidades/macae/index.html
@@ -70,7 +70,7 @@
                         <li><a href="#promocoes">Promoções</a></li>
 
                         <li><a href="#galeria-unidade">Galeria</a></li>
-                        <li><a href="../../index.html#contato">Seja Franqueado</a></li>
+                        <li><a href="../../franqueado.html">Seja Franqueado</a></li>
                         <li><a href="#contato-unidade">Contato</a></li>
                     </ul>
                 </nav>

--- a/unidades/rio-das-ostras-centro/index.html
+++ b/unidades/rio-das-ostras-centro/index.html
@@ -70,7 +70,7 @@
                         <li><a href="#promocoes">Promoções</a></li>
 
                         <li><a href="#galeria-unidade">Galeria</a></li>
-                        <li><a href="../../index.html#contato">Seja Franqueado</a></li>
+                        <li><a href="../../franqueado.html">Seja Franqueado</a></li>
                         <li><a href="#contato-unidade">Contato</a></li>
                     </ul>
                 </nav>

--- a/unidades/rio-das-ostras-plaza-shopping/index.html
+++ b/unidades/rio-das-ostras-plaza-shopping/index.html
@@ -73,7 +73,7 @@
                         <li><a href="#promocoes">Promoções</a></li>
 
                         <li><a href="#galeria-unidade">Galeria</a></li>
-                        <li><a href="../../index.html#contato">Seja Franqueado</a></li>
+                        <li><a href="../../franqueado.html">Seja Franqueado</a></li>
                         <li><a href="#contato-unidade">Contato</a></li>
                     </ul>
                 </nav>

--- a/unidades/sao-jose-dos-campos/index.html
+++ b/unidades/sao-jose-dos-campos/index.html
@@ -80,7 +80,7 @@
                         <li><a href="#promocoes">Promoções</a></li>
 
                         <li><a href="#galeria-unidade">Galeria</a></li>
-                        <li><a href="../../index.html#contato">Seja Franqueado</a></li>
+                        <li><a href="../../franqueado.html">Seja Franqueado</a></li>
                         <li><a href="#contato-unidade">Contato</a></li>
                     </ul>
                 </nav>


### PR DESCRIPTION
The links were previously pointing to the contact section of the main index page (`index.html#contato`), and have been updated to point to the correct `franqueado.html` page.